### PR TITLE
Disabled waiting for first data on iOS by default and timeout parameter added

### DIFF
--- a/lib/flutter_audio_capture.dart
+++ b/lib/flutter_audio_capture.dart
@@ -22,6 +22,14 @@ class FlutterAudioCapture {
 
   double? _actualSampleRate;
 
+  /// Starts listenening to audio.
+  ///
+  /// Uses [sampleRate] and [bufferSize] for capturing audio.
+  /// Uses [androidAudioSource] to determine recording type on Android.
+  /// When [waitForFirstDataOnAndroid] is set, it waits for [firstDataTimeout] duration on first data to arrive.
+  /// Will not listen if first date does not arrive in time. Set as [true] by default on Android.
+  /// When [waitForFirstDataOnIOS] is set, it waits for [firstDataTimeout] duration on first data to arrive.
+  /// Known to not work reliably on iOS and set as [false] by default.
   Future<void> start(Function listener, Function onError,
       {int sampleRate = 44000, int bufferSize = 5000, int androidAudioSource = ANDROID_AUDIOSRC_DEFAULT,
       Duration firstDataTimeout = const Duration(seconds: 1),

--- a/lib/flutter_audio_capture.dart
+++ b/lib/flutter_audio_capture.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 
@@ -22,46 +23,53 @@ class FlutterAudioCapture {
   double? _actualSampleRate;
 
   Future<void> start(Function listener, Function onError,
-      {int sampleRate = 44000, int bufferSize = 5000, int audioSource = ANDROID_AUDIOSRC_DEFAULT}) async {
+      {int sampleRate = 44000, int bufferSize = 5000, int androidAudioSource = ANDROID_AUDIOSRC_DEFAULT,
+      Duration firstDataTimeout = const Duration(seconds: 1),
+      bool waitForFirstDataOnAndroid = true, bool waitForFirstDataOnIOS = false}) async {
     if (_audioCaptureEventChannelSubscription != null) return;
     final stream = _audioCaptureEventChannel.receiveBroadcastStream({
       "sampleRate": sampleRate,
       "bufferSize": bufferSize,
-      "audioSource": audioSource,
+      "audioSource": androidAudioSource,
     });
 
-    // wait for the first data, then we know we have actual values
-    final initCompleter = Completer<void>();
-    _actualSampleRate = null;
+    final waitForFirstData = (Platform.isAndroid && waitForFirstDataOnAndroid) || (Platform.isIOS && waitForFirstDataOnIOS);
+    if (waitForFirstData) {      
+      // wait for the first data, then we know we have actual values
+      final initCompleter = Completer<void>();
+      _actualSampleRate = null;
 
-    // be careful here: _audioCaptureEventChannel exists the whole time, callback may be called
-    // from what was already there when we called "listen" - so wait until "getSampleRate" returns
-    // meaningful value or we timeout
-    final tempListener = stream.listen(
-      (_) async {
-        if ((_actualSampleRate ?? 0) < 10) {
-          _actualSampleRate = await _audioCaptureMethodChannel.invokeMethod<double>("getSampleRate");
-          if ((_actualSampleRate ?? 0) >= 10 && !initCompleter.isCompleted) //
+      // be careful here: _audioCaptureEventChannel exists the whole time, callback may be called
+      // from what was already there when we called "listen" - so wait until "getSampleRate" returns
+      // meaningful value or we timeout
+      final tempListener = stream.listen(
+        (_) async {
+          if ((_actualSampleRate ?? 0) < 10) {
+            _actualSampleRate = await _audioCaptureMethodChannel.invokeMethod<double>("getSampleRate");
+            if ((_actualSampleRate ?? 0) >= 10 && !initCompleter.isCompleted) //
+              initCompleter.complete();
+          }
+        },
+        onError: (Object e) {
+          print('Microphone init error $e');
+          if (!initCompleter.isCompleted) //
             initCompleter.complete();
-        }
-      },
-      onError: (Object e) {
-        print('Microphone init error $e');
-        if (!initCompleter.isCompleted) //
-          initCompleter.complete();
-      },
-    );
+        },
+      );
 
-    // wait until first data processed (or timeout)
-    await initCompleter.future.timeout(
-      Duration(seconds: 1),
-      onTimeout: () => null,
-    );
-    await tempListener.cancel();
+      // wait until first data processed (or timeout)
+      await initCompleter.future.timeout(
+        firstDataTimeout,
+        onTimeout: () => null,
+      );
+      await tempListener.cancel();
 
-    // start listening
-    if (_actualSampleRate != null && _actualSampleRate! > 0) //
+      // start listening
+      if (_actualSampleRate != null && _actualSampleRate! > 0) //
+        _audioCaptureEventChannelSubscription = stream.listen(listener as void Function(dynamic)?, onError: onError);
+    } else {
       _audioCaptureEventChannelSubscription = stream.listen(listener as void Function(dynamic)?, onError: onError);
+    }
   }
 
   Future<void> stop() async {


### PR DESCRIPTION
This PR addresses the issue with latest versions not working on iOS: https://github.com/ysak-y/flutter_audio_capture/issues/16

By default, iOS no longer waits for first data to arrive. Instead a parameter is added for this behaviour. A timeout parameter is also added in case we have to wait longer on iOS for the data to arrive.