### PR TITLE
Fix build error on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ group 'com.ymd.flutter_audio_capture'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
I tried using this package in an Android app on Flutter 3.13.0 and got this error:

```
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
The following dependencies do not satisfy the required version:
project ':flutter_audio_capture' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50
```

Removing this version constraint line fixes the error for me. TBH I'm not an expert in gradle, so I'm not sure if that line is needed for some other reason, but my app builds fine now.