### PR TITLE
Use a setup and improve sampleRate transport

### DIFF
--- a/android/src/main/kotlin/com/ymd/flutter_audio_capture/AudioCaptureStreamHandler.kt
+++ b/android/src/main/kotlin/com/ymd/flutter_audio_capture/AudioCaptureStreamHandler.kt
@@ -84,13 +84,16 @@ public class AudioCaptureStreamHandler: StreamHandler {
 
     private fun sendBuffer(audioBuffer: ArrayList<FloatArray>, bufferIndex: Int) {
         uiThreadHandler.post(object: Runnable {
-            var index: Int = -1 
+            var index: Int = -1
 
             override fun run() {
                 if (isCapturing) {
-                    // There was only one audio buffer, converted with .toList() here. Causes frequent GC runs.
-                    // Also, array might/should prevent overwriting samples while they are passed to Dart.
-                    _events?.success(audioBuffer[index])
+                    // Send the actualSampleRate as a special event
+                    val data = mapOf(
+                        "actualSampleRate" to actualSampleRate.toDouble(),
+                        "audioData" to audioBuffer[index]
+                    )
+                    _events?.success(data)
                 }
             }
 

--- a/android/src/main/kotlin/com/ymd/flutter_audio_capture/FlutterAudioCapturePlugin.kt
+++ b/android/src/main/kotlin/com/ymd/flutter_audio_capture/FlutterAudioCapturePlugin.kt
@@ -39,6 +39,10 @@ public class FlutterAudioCapturePlugin: FlutterPlugin, MethodCallHandler {
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
     when (call.method) {
+      "init" -> {
+        // For now, we do nothing to init on android
+        result.success(true)
+      }
       "getSampleRate" -> {
         result.success(this.audioCaptureStreamHandler.actualSampleRate.toDouble())
       }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -16,6 +16,8 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+    // Need to initialize before use note that this is async!
+    _plugin.init();
   }
 
   Future<void> _startCapture() async {

--- a/ios/Classes/AudioCapture.swift
+++ b/ios/Classes/AudioCapture.swift
@@ -1,67 +1,68 @@
-import Foundation
 import AVFoundation
 
+/// `AudioCapture` is a class that handles audio recording and processing.
 public class AudioCapture {
-  let audioEngine: AVAudioEngine = AVAudioEngine()
-    private var outputFormat = AVAudioFormat(commonFormat: AVAudioCommonFormat.pcmFormatInt16, sampleRate: 44100, channels: 2, interleaved: true)
-  init() {
-      do{
-    let audioSession: AVAudioSession = AVAudioSession.sharedInstance()
-    try audioSession.setCategory(AVAudioSession.Category.playAndRecord,
-                                  mode: AVAudioSession.Mode.default,
-                                 options: [.defaultToSpeaker, .mixWithOthers, .allowBluetoothA2DP, .allowAirPlay, .allowBluetooth])
-    try audioSession.setActive(true)
-      }
-      catch let err {
-          print(err)
-      }
-  }
-  
-  deinit{
-    audioEngine.inputNode.removeTap(onBus: 0)
-    audioEngine.stop()
-  }
-  
-  public func startSession(bufferSize: UInt32, sampleRate: Double, cb: @escaping (_ buffer: Array<Float>) -> Void) throws {
-  
-    let inputNode = audioEngine.inputNode
-    let inputFormat  = inputNode.inputFormat(forBus: 0)
-    try! audioEngine.start()
-    inputNode.installTap(onBus: 0,
-                          bufferSize: bufferSize,
-                          format: inputFormat) { (buffer: AVAudioPCMBuffer, when: AVAudioTime) in
-                          // Convert audio format from 44100Hz to passed sampleRate
-                          // https://medium.com/@prianka.kariat/changing-the-format-of-ios-avaudioengine-mic-input-c183459cab63
-                          let formatToConvert = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                                                sampleRate:   sampleRate,
-                                                                channels:     1,
-                                                                interleaved:  true)!
-                          if buffer.format != formatToConvert {
-                            var convertedBuffer: AVAudioPCMBuffer? = buffer
-                            if let converter = AVAudioConverter(from: inputFormat, to: formatToConvert) {
-                              convertedBuffer = AVAudioPCMBuffer(pcmFormat:  formatToConvert,
-                                                                  // frameCapacity: AVAudioFrameCount( formatToConvert.sampleRate * 0.4))
-                                                                  frameCapacity: AVAudioFrameCount(self.outputFormat!.sampleRate) * buffer.frameLength / AVAudioFrameCount(buffer.format.sampleRate))
-                              let inputBlock : AVAudioConverterInputBlock = { (inNumPackets, outStatus) -> AVAudioBuffer? in
-                                outStatus.pointee = AVAudioConverterInputStatus.haveData
-                                let audioBuffer : AVAudioBuffer = buffer
-                                return audioBuffer
-                              }
-                              var error : NSError?
-                              if let uwConvertedBuffer = convertedBuffer {
-                                converter.convert(to: uwConvertedBuffer, error: &error, withInputFrom: inputBlock)
-                                cb(Array(UnsafeBufferPointer(start: uwConvertedBuffer.floatChannelData![0], count:Int(uwConvertedBuffer.frameLength))))
-                              }
-                            }
-                          } else {
-                             cb(Array(UnsafeBufferPointer(start: buffer.floatChannelData![0], count:Int(buffer.frameLength))))
-                          }
-    }
-          
-  }
+    /// `audioEngine` is an instance of `AVAudioEngine` used for audio input and output.
+    let audioEngine = AVAudioEngine()
 
-  public func stopSession() throws {
-    audioEngine.inputNode.removeTap(onBus: 0)
-    audioEngine.stop()
-  }
+    /// `setup` is a method that sets up the audio session for recording.
+    /// It sets the audio session category to `.record` and activates the audio session.
+    /// - Returns: A boolean indicating whether the audio session was successfully activated.
+    /// - Throws: An error if the audio session could not be set up.
+    public func setup() throws -> Bool {
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record, mode: .measurement, options: [.mixWithOthers])
+        do {
+            try audioSession.setActive(true)
+            return true
+        } catch {
+            print("Failed to activate AudioSession: \(error)")
+            return false
+        }
+    }
+    
+    /// `startSession` is a method that starts the audio recording session.
+    /// It installs a tap on the input node of the audio engine to capture audio data.
+    /// - Parameters:
+    ///   - bufferSize: The size of the buffer for the audio data.
+    ///   - sampleRate: The sample rate for the audio data.
+    ///   - cb: A callback function that is called with the audio data and sample rate.
+    /// - Throws: An error if the audio engine could not be started.
+    public func startSession(bufferSize: UInt32, sampleRate: Double, cb: @escaping (FlutterStandardTypedData?, Double, Error?) -> Void) throws {
+        let inputNode = audioEngine.inputNode
+        let inputFormat  = inputNode.inputFormat(forBus: 0)
+        
+        inputNode.installTap(onBus: 0, bufferSize: bufferSize, format: inputFormat) { (buffer, _) in
+            // Convert audio format from 44100Hz to passed sampleRate
+            // https://medium.com/@prianka.kariat/changing-the-format-of-ios-avaudioengine-mic-input-c183459cab63
+            let formatToConvert = AVAudioFormat(commonFormat: .pcmFormatFloat32, sampleRate: sampleRate, channels: 1, interleaved: true)!
+            guard let converter = AVAudioConverter(from: inputFormat, to: formatToConvert) else {
+                cb(nil, sampleRate, NSError(domain: "AudioCapture", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to create AVAudioConverter"]))
+                return
+            }
+            let convertedBuffer: AVAudioPCMBuffer? = AVAudioPCMBuffer(pcmFormat:  formatToConvert, frameCapacity: AVAudioFrameCount(formatToConvert.sampleRate) * buffer.frameLength / AVAudioFrameCount(buffer.format.sampleRate))
+            let inputBlock : AVAudioConverterInputBlock = { (_, outStatus) -> AVAudioBuffer? in
+                outStatus.pointee = AVAudioConverterInputStatus.haveData
+                return buffer
+            }
+            var error: NSError?
+            converter.convert(to: convertedBuffer!, error: &error, withInputFrom: inputBlock)
+            if let error = error {
+                cb(nil, sampleRate, error)
+                return
+            }
+            let data = Data(buffer: UnsafeBufferPointer(start: convertedBuffer!.floatChannelData![0], count:Int(convertedBuffer!.frameLength)))
+            let flutterData = FlutterStandardTypedData(float32: data)
+            cb(flutterData, sampleRate, nil)
+        }
+        
+        try audioEngine.start()
+    }
+    
+    /// `stopSession` is a method that stops the audio recording session.
+    /// It removes the tap on the input node of the audio engine and stops the audio engine.
+    public func stopSession() {
+        audioEngine.inputNode.removeTap(onBus: 0)
+        audioEngine.stop()
+    }
 }

--- a/ios/Classes/AudioCaptureEventStreamHandler.swift
+++ b/ios/Classes/AudioCaptureEventStreamHandler.swift
@@ -1,59 +1,54 @@
 enum AudioCaptureEventStreamHandlerErrorCode {
-  static let onListenFailed = "ON_LISTEN_FAILED"
-  static let onCancelFailed = "ON_CANCEL_FAILED"
+    static let onListenFailed = "ON_LISTEN_FAILED"
+    static let whileListeningFailed = "WHILE_LISTENING_FAILED"
 }
 
 class AudioCaptureEventStreamHandler: NSObject, FlutterStreamHandler {
-  public let eventChannelName = "ymd.dev/audio_capture_event_channel"
-  private let audioCapture: AudioCapture = AudioCapture()
-  private var eventSink: FlutterEventSink?
-  public var actualSampleRate:Float64?;
-
-  public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
-    self.eventSink = events
-
-    var bufferSize: UInt32 = 4000
-    var sampleRate: Double = 16000.0
-    if let args = arguments as? Dictionary<String, Any> {
-      if args.keys.contains("bufferSize"),
-          let bufSize = args["bufferSize"] as? UInt32 {
-        bufferSize = bufSize
-      }
-      
-      if args.keys.contains("sampleRate"),
-          let rate = args["sampleRate"] as? Double {
-        sampleRate = rate
-      }
+    let eventChannelName = "ymd.dev/audio_capture_event_channel"
+    let audioCapture = AudioCapture()
+    var eventSink: FlutterEventSink?
+    var actualSampleRate:Float64?
+    
+    func setup() throws -> Bool {
+        return try audioCapture.setup()
     }
     
-    self.actualSampleRate = sampleRate; // This should come from audioCapture
-    
-    if let sink: FlutterEventSink = self.eventSink {
-      do {
-        try self.audioCapture.startSession(bufferSize: bufferSize, sampleRate: sampleRate) { buffer in
-          sink(buffer)
+    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
+        eventSink = events
+        let args = arguments as? Dictionary<String, Any> ?? [:]
+        let bufferSize: UInt32 = args["bufferSize"] as? UInt32 ?? 4000
+        let sampleRate: Double = args["sampleRate"] as? Double ?? 16000.0
+        actualSampleRate = sampleRate
+        do {
+            try audioCapture.startSession(bufferSize: bufferSize, sampleRate: sampleRate) { buffer, sampleRate, err in
+                if let e = err {
+                    self.sendToFlutter(FlutterError(code: AudioCaptureEventStreamHandlerErrorCode.whileListeningFailed,
+                                                    message: "Error occured while starting audio capture",
+                                                    details: e.localizedDescription))
+                } else if let audioData = buffer {
+                    self.sendToFlutter([
+                        "actualSampleRate": sampleRate,
+                        "audioData": audioData
+                    ])
+                }
+            }
+        } catch let error{
+            sendToFlutter(FlutterError(code: AudioCaptureEventStreamHandlerErrorCode.onListenFailed,
+                                       message: "Error occured while starting audio capture",
+                                       details: error.localizedDescription))
         }
-      } catch {
-        sink(FlutterError(code: AudioCaptureEventStreamHandlerErrorCode.onListenFailed,
-                        message: "Error occured in onListen",
-                        details: nil))
-      }
+        return nil
     }
-    return nil
-  }
-
-  public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-    self.actualSampleRate = nil
-
-    if let sink: FlutterEventSink = self.eventSink {
-      do {
-        try self.audioCapture.stopSession()
-      } catch {
-        sink(FlutterError(code: AudioCaptureEventStreamHandlerErrorCode.onCancelFailed,
-                        message: "Error occured in onCancel",
-                        details: nil))
-      }
+    
+    func onCancel(withArguments arguments: Any?) -> FlutterError? {
+        actualSampleRate = nil
+        audioCapture.stopSession()
+        return nil
     }
-    return nil
-  }
+    
+    private func sendToFlutter(_ event: Any) {
+        DispatchQueue.main.async {
+            self.eventSink?(event)
+        }
+    }
 }

--- a/ios/Classes/SwiftFlutterAudioCapturePlugin.swift
+++ b/ios/Classes/SwiftFlutterAudioCapturePlugin.swift
@@ -2,30 +2,35 @@ import Flutter
 import UIKit
 
 public class SwiftFlutterAudioCapturePlugin: NSObject, FlutterPlugin {
-  var instance: AudioCaptureEventStreamHandler
-    
-  init(instance: AudioCaptureEventStreamHandler){
-    self.instance = instance
-    super.init()
-  }
-    
-  public static func register(with registrar: FlutterPluginRegistrar) {
-    let methodChannelName = "ymd.dev/audio_capture_method_channel"
-    let instance: AudioCaptureEventStreamHandler = AudioCaptureEventStreamHandler()
-      
-    FlutterEventChannel(name: instance.eventChannelName, binaryMessenger: registrar.messenger()).setStreamHandler(instance)
+    var instance: AudioCaptureEventStreamHandler
 
-    let methodChannel = FlutterMethodChannel(name: methodChannelName, binaryMessenger: registrar.messenger())
-      registrar.addMethodCallDelegate(SwiftFlutterAudioCapturePlugin(instance: instance), channel: methodChannel)
-  }
-  
-  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    switch call.method {
-      case "getSampleRate":
-        result(instance.actualSampleRate)
-        break;
-      default:
-        result(FlutterMethodNotImplemented)
+    init(instance: AudioCaptureEventStreamHandler){
+        self.instance = instance
+        super.init()
     }
-  }
+
+    public static func register(with registrar: FlutterPluginRegistrar) {
+        let methodChannelName = "ymd.dev/audio_capture_method_channel"
+        let instance = AudioCaptureEventStreamHandler()
+
+        FlutterEventChannel(name: instance.eventChannelName, binaryMessenger: registrar.messenger()).setStreamHandler(instance)
+
+        let methodChannel = FlutterMethodChannel(name: methodChannelName, binaryMessenger: registrar.messenger())
+        registrar.addMethodCallDelegate(SwiftFlutterAudioCapturePlugin(instance: instance), channel: methodChannel)
+    }
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        switch call.method {
+        case "getSampleRate":
+            result(instance.actualSampleRate)
+        case "init":
+            do {
+                result(try instance.setup())
+            } catch {
+                result(FlutterError(code: "initFailed", message: "Error occured in init", details: error.localizedDescription))
+            }
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
 }

--- a/lib/flutter_audio_capture.dart
+++ b/lib/flutter_audio_capture.dart
@@ -85,7 +85,14 @@ class FlutterAudioCapture {
     // Prevent stream for starting over because we have no listenre between firstWhere check and this line which initally was at the end of the code
     _audioCaptureEventChannelSubscription = audioStream.skipWhile((element) => !completer.isCompleted).listen(listener, onError: onError);
     if (waitForFirstData) {
-      await audioStream.firstWhere((element) => (_actualSampleRate ?? 0) > 10).timeout(firstDataTimeout);
+      try {
+        await audioStream.firstWhere((element) => (_actualSampleRate ?? 0) > 10).timeout(firstDataTimeout);
+      } catch (e) {
+        // If we timeout, cancel the stream and throw error
+        completer.completeError(e);
+        await stop();
+        rethrow;
+      }
     }
     completer.complete();
 

--- a/lib/flutter_audio_capture.dart
+++ b/lib/flutter_audio_capture.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 
@@ -15,12 +16,24 @@ const ANDROID_AUDIOSRC_UNPROCESSED = 9;
 
 class FlutterAudioCapture {
   static const _audioCaptureEventChannel = EventChannel(AUDIO_CAPTURE_EVENT_CHANNEL_NAME);
+
   // ignore: cancel_subscriptions
   StreamSubscription? _audioCaptureEventChannelSubscription;
 
   static const _audioCaptureMethodChannel = MethodChannel(AUDIO_CAPTURE_METHOD_CHANNEL_NAME);
 
   double? _actualSampleRate;
+
+  bool? _initialized;
+
+
+  Future<bool?> init() async {
+    // Only init once
+    if (_initialized != null) return _initialized;
+    _initialized = await _audioCaptureMethodChannel.invokeMethod<bool>("init");
+    return _initialized;
+  }
+
 
   /// Starts listenening to audio.
   ///
@@ -30,54 +43,52 @@ class FlutterAudioCapture {
   /// Will not listen if first date does not arrive in time. Set as [true] by default on Android.
   /// When [waitForFirstDataOnIOS] is set, it waits for [firstDataTimeout] duration on first data to arrive.
   /// Known to not work reliably on iOS and set as [false] by default.
-  Future<void> start(Function listener, Function onError,
-      {int sampleRate = 44000, int bufferSize = 5000, int androidAudioSource = ANDROID_AUDIOSRC_DEFAULT,
-      Duration firstDataTimeout = const Duration(seconds: 1),
-      bool waitForFirstDataOnAndroid = true, bool waitForFirstDataOnIOS = false}) async {
+  Future<void> start(void Function(Float32List) listener, Function onError,
+      {int sampleRate = 44100, int bufferSize = 5000, int androidAudioSource = ANDROID_AUDIOSRC_DEFAULT,
+        Duration firstDataTimeout = const Duration(seconds: 1),
+        bool waitForFirstDataOnAndroid = true, bool waitForFirstDataOnIOS = false}) async {
+    if (_initialized == null) {
+      throw Exception("FlutterAudioCapture must be initialized before use");
+    }
+
+    if (_initialized == false) {
+      throw Exception("FlutterAudioCapture failed to initialize");
+    }
+
+    // We are already listening
     if (_audioCaptureEventChannelSubscription != null) return;
+    // init channel stream
     final stream = _audioCaptureEventChannel.receiveBroadcastStream({
       "sampleRate": sampleRate,
       "bufferSize": bufferSize,
       "audioSource": androidAudioSource,
+    }).cast<Map>();
+    // The channel will have format:
+    // {
+    //   "audioData": Float32List,
+    //   "actualSampleRate": double,
+    // }
+
+    _actualSampleRate = null;
+    var audioStream = stream.map((event) {
+      _actualSampleRate = event.get('actualSampleRate');
+      return event.get('audioData') as Float32List;
     });
 
-    final waitForFirstData = (Platform.isAndroid && waitForFirstDataOnAndroid) || (Platform.isIOS && waitForFirstDataOnIOS);
-    if (waitForFirstData) {      
-      // wait for the first data, then we know we have actual values
-      final initCompleter = Completer<void>();
-      _actualSampleRate = null;
 
-      // be careful here: _audioCaptureEventChannel exists the whole time, callback may be called
-      // from what was already there when we called "listen" - so wait until "getSampleRate" returns
-      // meaningful value or we timeout
-      final tempListener = stream.listen(
-        (_) async {
-          if ((_actualSampleRate ?? 0) < 10) {
-            _actualSampleRate = await _audioCaptureMethodChannel.invokeMethod<double>("getSampleRate");
-            if ((_actualSampleRate ?? 0) >= 10 && !initCompleter.isCompleted) //
-              initCompleter.complete();
-          }
-        },
-        onError: (Object e) {
-          print('Microphone init error $e');
-          if (!initCompleter.isCompleted) //
-            initCompleter.complete();
-        },
-      );
+    // Do we need to wait for first data?
+    final waitForFirstData = (Platform.isAndroid && waitForFirstDataOnAndroid) ||
+        (Platform.isIOS && waitForFirstDataOnIOS);
 
-      // wait until first data processed (or timeout)
-      await initCompleter.future.timeout(
-        firstDataTimeout,
-        onTimeout: () => null,
-      );
-      await tempListener.cancel();
 
-      // start listening
-      if (_actualSampleRate != null && _actualSampleRate! > 0) //
-        _audioCaptureEventChannelSubscription = stream.listen(listener as void Function(dynamic)?, onError: onError);
-    } else {
-      _audioCaptureEventChannelSubscription = stream.listen(listener as void Function(dynamic)?, onError: onError);
+    Completer<void>? completer = Completer();
+    // Prevent stream for starting over because we have no listenre between firstWhere check and this line which initally was at the end of the code
+    _audioCaptureEventChannelSubscription = audioStream.skipWhile((element) => !completer.isCompleted).listen(listener, onError: onError);
+    if (waitForFirstData) {
+      await audioStream.firstWhere((element) => (_actualSampleRate ?? 0) > 10).timeout(firstDataTimeout);
     }
+    completer.complete();
+
   }
 
   Future<void> stop() async {
@@ -89,4 +100,15 @@ class FlutterAudioCapture {
   }
 
   double? get actualSampleRate => _actualSampleRate;
+}
+
+
+extension MapUtil on Map{
+  T get<T>(String key) {
+    return this[key]!;
+  }
+
+  T? getOrNull<T>(String key) {
+    return this[key];
+  }
 }


### PR DESCRIPTION
I was able to identify that issue #26 is caused by the `AVAudioSession` starting up when the app launches. I have addressed this by removing that section of code and creating a separate method for it.

In addition, on the iOS platform, Flutter will now receive a `Float32List` instead of a `List<Object?>`, which has made the code more type-safe (#23).

I've also reworked how the `waitForFirstData` function works. It will now throw a `TimeoutError` if the timeout is exceeded, rather than doing nothing. This change also necessitated a reworking of how the sample rate is fetched. The `actualSampleRate` is now reported alongside each new `Float32List` audio event.

I also added a few more errors/throwing code on the IOS side.

Fix #26, Fix #23