### PR TITLE
Replace jcenter with mavenCentral in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.7.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -22,7 +22,7 @@ version '1.0-SNAPSHOT'
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext.kotlin_version = '1.7.10'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -14,7 +14,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
This pull request updates the Gradle build configuration for both the main Android project and the example project. The most important change is replacing the deprecated `jcenter()` repository with `mavenCentral()` to ensure continued access to dependencies and improved build reliability.

Repository configuration updates:

* Replaced `jcenter()` with `mavenCentral()` in the `buildscript` and `allprojects` repository blocks in `android/build.gradle`. [[1]](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aL5-R5) [[2]](diffhunk://#diff-197b190e4a3512994d2cebed8aff5479ff88e136b8cc7a4b148ec9c3945bd65aL25-R25)
* Replaced `jcenter()` with `mavenCentral()` in the `buildscript` and `allprojects` repository blocks in `example/android/build.gradle`. [[1]](diffhunk://#diff-ed8534ece8080a880075e103269eb1b9bdff22e8dfcf8427d7d977603292b889L5-R5) [[2]](diffhunk://#diff-ed8534ece8080a880075e103269eb1b9bdff22e8dfcf8427d7d977603292b889L17-R17)