### PR TITLE
docs: Add required init() call to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,15 @@ void onError(Object e) {
 ...
 
 FlutterAudioCapture plugin = new FlutterAudioCapture();
+
+// Initialize the plugin (required before start)
+await plugin.init();
+
 // Start to capture audio stream buffer
 // sampleRate: sample rate you want
 // bufferSize: buffer size you want (iOS only)
 await plugin.start(listener, onError, sampleRate: 16000, bufferSize: 3000);
+
 // Stop to capture audio stream buffer
 await plugin.stop();
 ```


### PR DESCRIPTION
## What

Add the missing `init()` call to the usage example in README.md.

## Why

Users following the README example were getting the error "FlutterAudioCapture must be initialized before use" because the documentation did not show the required initialization step before calling `start()`.

Closes #44

## How

Added `await plugin.init();` with a comment explaining it is required before `start()` in the Example section of README.md.
